### PR TITLE
Allow manual launch of many-platforms.yml

### DIFF
--- a/.github/workflows/many-platforms.yml
+++ b/.github/workflows/many-platforms.yml
@@ -37,6 +37,8 @@ on:
     # Doc: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # POSIX cron syntax: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
     - cron: '50 9 * * 1'
+  workflow_dispatch:
+    # Doc: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
 
 # Variables.
 env:


### PR DESCRIPTION
This adds this button to the [many-platforms.yml action page](https://github.com/gnu-gettext/ci-check/actions/workflows/many-platforms.yml):

![immagine](https://github.com/user-attachments/assets/db0147c5-9f9e-4c4d-939a-e3b8601c6cbd)

(it will no longer be necessary to push an empty commit to trigger the action)